### PR TITLE
[Feature] Add support for optional socials

### DIFF
--- a/coeus_sphinx_theme/contributors.html.jinja
+++ b/coeus_sphinx_theme/contributors.html.jinja
@@ -4,15 +4,20 @@ Coeus Sphinx Theme Contributors Template
 
 Author: Akshay Mestry <xa@mes3.dev>
 Created on: Tuesday, October 29 2024
-Last updated on: Tuesday, October 29 2024
+Last updated on: Wednesday, October 30 2024
 -->
 {% block contributors_metadata %}
 {%- if people %}
 {%- set prefix = prefix|d("Published by") -%}
 {%- set names = people | map(attribute="name") | list -%}
 {%- set emails = people | map(attribute="email") | list -%}
-{%- set usernames = people | map(attribute="github") | list -%}
+{%- set githubs = people | map(attribute="github") | list -%}
 {%- set headshots = people | map(attribute="headshot") | list -%}
+{%- set orcids = people | map(attribute="orcid") | list -%}
+{%- set linkedins = people | map(attribute="linkedin") | list -%}
+{%- set twitters = people | map(attribute="twitter") | list -%}
+{%- set youtubes = people | map(attribute="youtube") | list -%}
+{%- set statuses = people | map(attribute="status") | list -%}
 {%- set contributors = names | length -%}
 {%- set limit = limit if limit and limit > 1 and limit - 1 < contributors else 2 -%}
 <div class="contributors-wrapper">
@@ -71,13 +76,29 @@ Last updated on: Tuesday, October 29 2024
     {% for name in names %}
         <div id="contributors-publisher-modal-{{ loop.index0 }}" class="contributors-publisher-modal">
             <div style="display: flex; gap: 0.25rem;">
-                <img src="{{ headshots[loop.index0] }}" alt="{{ name }}'s photo">
+                <img src="{{ headshots[loop.index0]|d('https://static.thenounproject.com/png/4035892-200.png') }}" alt="{{ name }}'s photo">
                 <div class="contributor-identity">
                     <p>{{ name }}</p>
+                    <p style="font-weight: 400; font-size: 0.85rem; color: gray; margin-top: -0.25rem; margin-bottom: 0.25rem;">{{ statuses[loop.index0]|d('Open Science Contributor') }}</p>
                     <div class="contributor-reachout-details">
-                        <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="mailto:{{ emails[loop.index0] }}"><i class="fa-solid fa-envelope" style="padding-right: 0.3rem;"></i>Email</a></p>
-                        <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="{{ usernames[loop.index0] }}" target="_blank"><i class="fa-brands fa-github" style="padding-right: 0.3rem;"></i>GitHub</a></p>
-                        <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="#" target="_blank"><i class="fa-brands fa-orcid" style="padding-right: 0.3rem;"></i>ORCID</a></p>
+                        {% if emails[loop.index0] %}
+                            <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="mailto:{{ emails[loop.index0] }}"><i class="fa-solid fa-envelope" style="padding-right: 0.3rem;"></i>Email</a></p>
+                        {% endif %}
+                        {% if githubs[loop.index0] %}
+                            <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="{{ githubs[loop.index0] }}" target="_blank"><i class="fa-brands fa-github" style="padding-right: 0.3rem;"></i>GitHub</a></p>
+                        {% endif %}
+                        {% if orcids[loop.index0] %}
+                            <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="{{ orcids[loop.index0] }}" target="_blank"><i class="fa-brands fa-orcid" style="padding-right: 0.3rem;"></i>ORCID</a></p>
+                        {% endif %}
+                        {% if linkedins[loop.index0] %}
+                            <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="{{ linkedins[loop.index0] }}" target="_blank"><i class="fa-brands fa-linkedin" style="padding-right: 0.3rem;"></i>LinkedIn</a></p>
+                        {% endif %}
+                        {% if twitters[loop.index0] %}
+                            <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="{{ twitters[loop.index0] }}" target="_blank"><i class="fa-brands fa-x-twitter" style="padding-right: 0.3rem;"></i>Twitter</a></p>
+                        {% endif %}
+                        {% if youtubes[loop.index0] %}
+                            <p class="contributors-metadata-badge" style="margin-right: 0.25rem;"><a href="{{ youtubes[loop.index0] }}" target="_blank"><i class="fa-brands fa-youtube" style="padding-right: 0.3rem;"></i>YouTube</a></p>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/coeus_sphinx_theme/extensions/contributors.py
+++ b/coeus_sphinx_theme/extensions/contributors.py
@@ -4,7 +4,7 @@ Coeus Sphinx Theme Contributors Directive
 
 Author: Akshay Mestry <xa@mes3.dev>
 Created on: Wednesday, August 14 2024
-Last updated on: Wednesday, October 23 2024
+Last updated on: Wednesday, October 30 2024
 
 This module provides a custom directive for the Coeus Sphinx Theme,
 that allows authors and contributors to add information about themselves
@@ -66,6 +66,9 @@ contributors when building the documentation.
 .. versionadded:: 2024.11.01
 
     [1] Added support for on hover modal popup for contributors.
+    [2] Added support for proper resolving images over `http/s`.
+    [3] Added support for optional extra social media connections like
+        ORCID, LinkedIn, Twitter and YouTube.
 """
 
 from __future__ import annotations
@@ -133,10 +136,15 @@ class directive(rst.Directive):
         .. versionadded:: 2024.11.01
 
             [1] Added support for on hover modal popup for contributors.
+            [2] Added support for proper resolving images over `http/s`.
+            [3] Added support for optional extra social media
+                connections like ORCID, LinkedIn, Twitter and YouTube.
         """
         self.assert_has_content()
-        env = self.state.document.settings.env
-        build = os.path.dirname(env.doctreedir)
+        e = self.state.document.settings.env
+        build = os.path.dirname(e.doctreedir)
+        if not os.path.exists((images := os.path.join(build, "_images"))):
+            os.makedirs(images, exist_ok=True)
         person = 0
         people = [{}]
         for content in self.content:
@@ -151,14 +159,28 @@ class directive(rst.Directive):
                             people[person]["name"] = value
                         case "email":
                             people[person]["email"] = value
+                        case "headshot":
+                            if not value.startswith(("http://", "https://")):
+                                r = relpath_re.match(value).group()
+                                s = os.path.join(e.srcdir, value.lstrip("./"))
+                                _ = os.path.basename(s)
+                                d = os.path.join("_images", _)
+                                people[person]["headshot"] = os.path.join(r, d)
+                                shutil.copyfile(s, os.path.join(build, d))
+                            else:
+                                people[person]["headshot"] = value
                         case "github":
                             people[person]["github"] = value
-                        case "headshot":
-                            rp = relpath_re.match(value).group()
-                            sd = os.path.join(env.srcdir, value.lstrip("./"))
-                            dd = os.path.join("_images", os.path.basename(sd))
-                            people[person]["headshot"] = os.path.join(rp, dd)
-                            shutil.copyfile(sd, os.path.join(build, dd))
+                        case "orcid":
+                            people[person]["orcid"] = value
+                        case "linkedin":
+                            people[person]["linkedin"] = value
+                        case "twitter":
+                            people[person]["twitter"] = value
+                        case "youtube":
+                            people[person]["youtube"] = value
+                        case "status":
+                            people[person]["status"] = value
         element = node("\n".join(self.content), **self.options)
         element.attributes["people"] = people
         return [element]


### PR DESCRIPTION
**Description of the change:**

  - This brings the support for adding various new social media connections like LinkedIn, ORCID, Twitter and YouTube to the modal pop-up.
  - This change also fixes the issue with rendering images over URL. With this change, the images need not be necessarily stored on the device and can be parsed directly over the internet.

**References:**

  - #13 (GitHub issue)