### PR TITLE
Fix code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/coeus_sphinx_theme/static/coeus.js
+++ b/coeus_sphinx_theme/static/coeus.js
@@ -102,19 +102,21 @@ function switchLanguage() {
     var regex = new RegExp('\/(' + supportedLanguages.join('|') + ')\/');
     var currentLanguage = currentUrl.match(regex);
 
-    if (selectedLanguage !== 'en') {
-        if (currentLanguage) {
-            newUrl = currentUrl.replace(regex, '/' + selectedLanguage + '/');
+    if (supportedLanguages.includes(selectedLanguage)) {
+        if (selectedLanguage !== 'en') {
+            if (currentLanguage) {
+                newUrl = currentUrl.replace(regex, '/' + encodeURIComponent(selectedLanguage) + '/');
+            } else {
+                newUrl = currentUrl.endsWith('/') ? currentUrl + encodeURIComponent(selectedLanguage) + '/' : currentUrl + '/' + encodeURIComponent(selectedLanguage) + '/';
+            }
         } else {
-            newUrl = currentUrl.endsWith('/') ? currentUrl + selectedLanguage + '/' : currentUrl + '/' + selectedLanguage + '/';
+            if (currentLanguage) {
+                newUrl = currentUrl.replace(regex, '/');
+            }
         }
-    } else {
-        if (currentLanguage) {
-            newUrl = currentUrl.replace(regex, '/');
+        if (newUrl) {
+            window.location.href = newUrl;
         }
-    }
-    if (newUrl) {
-        window.location.href = newUrl;
     }
 }
 


### PR DESCRIPTION
Fixes [https://github.com/xames3/coeus-sphinx-theme/security/code-scanning/1](https://github.com/xames3/coeus-sphinx-theme/security/code-scanning/1)

To fix the problem, we need to ensure that the `selectedLanguage` value is properly validated and sanitized before it is used to construct the `newUrl`. We can achieve this by:
1. Validating that the `selectedLanguage` value is one of the supported languages.
2. Escaping any potentially harmful characters in the `selectedLanguage` value before using it in the URL.

We will update the code to include a validation check and use a safer method to construct the `newUrl`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
