### PR TITLE
[Build] Drop support for python 3.9 and older

### DIFF
--- a/coeus_sphinx_theme/extensions/notebook.py
+++ b/coeus_sphinx_theme/extensions/notebook.py
@@ -4,7 +4,7 @@ Coeus Sphinx Theme Notebook Directive
 
 Author: Akshay Mestry <xa@mes3.dev>
 Created on: Wednesday, October 09 2024
-Last updated on: Tuesday, October 29 2024
+Last updated on: Wednesday, November 27 2024
 
 This module provides a custom directive for the Coeus Sphinx Theme,
 that allows authors and contributors to embed a Jupyter Notebook or a
@@ -87,7 +87,8 @@ class directive(rst.Directive):
         base = self.options.get("basedir", "_jupyter")
         flags: str = ""
         if self.content:
-            url = f"../{base}/notebooks/?path={'\n'.join(self.content)}"
+            content = "\n".join(self.content)
+            url = f"../{base}/notebooks/?path={content}"
         if not self.content:
             url = f"../{base}/repl/index.html?"
             flags += "kernel=python&toolbar=1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "coeus-sphinx-theme"
 dynamic = [ "version", "dependencies" ]
 description = "A Sphinx Documentation Theme."
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license.file = "LICENSE"
 authors = [
   { name = "Akshay Mestry", email = "xa@mes3.dev" }
@@ -20,8 +20,6 @@ classifiers = [
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.8",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -69,10 +67,21 @@ disable_error_code = ["attr-defined", "index", "union-attr"]
 
 [tool.tox]
 requires = ["tox>=4"]
-envlist = ["py312", "py311", "py310", "py39", "py38", "static"]
+envlist = ["py312", "py311", "py310"]
 
-[tool.tox.env.static]
-deps = ["-r requirements-dev.txt"]
+[tool.tox.env_run_base]
+description = "Linting code and running static type checking on {base_python}"
+deps = [
+  "black",
+  "docutils-stubs",
+  "flake8",
+  "isort",
+  "mypy",
+  "mypy-extensions",
+  "types-beautifulsoup4",
+  "types-docutils",
+  "typing_extensions",
+]
 commands = [
   ["black", "-q", "coeus_sphinx_theme/"],
   ["flake8", "coeus_sphinx_theme/"],
@@ -85,5 +94,3 @@ commands = [
 "3.12" = ["3.12"]
 "3.11" = ["3.11"]
 "3.10" = ["3.10"]
-"3.9" = ["3.9"]
-"3.8" = ["3.8"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,0 @@
-black
-docutils-stubs
-flake8
-isort
-mypy
-mypy-extensions
-tox
-types-beautifulsoup4
-typing_extensions

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ sphinx-tags
 sphinx_design
 sphinxcontrib-jquery
 sphinxext-opengraph
+tox


### PR DESCRIPTION
- this drops the support for Coeus Sphinx Theme for python 3.9 and below versions. the key reason to drop support was non-conformity with the newer `match case` syntax.