### PR TITLE
[Fix] Side menu title overflow

### DIFF
--- a/coeus_sphinx_theme/static/coeus.css
+++ b/coeus_sphinx_theme/static/coeus.css
@@ -2032,6 +2032,7 @@ table:not(.does-not-exist):hover .navbarlink>* {
 .contents ul li ul,
 .toctree-wrapper ul li ul {
     padding-left: 1rem;
+    word-break: keep-all;
 }
 
 .contents ul:not(:last-child),

--- a/coeus_sphinx_theme/static/coeus.css
+++ b/coeus_sphinx_theme/static/coeus.css
@@ -1023,6 +1023,7 @@ table tbody td:not(:first-child) {
     margin-top: 3rem;
     margin-bottom: 1rem;
     padding-top: 1.5rem;
+    max-width: 15rem;
 }
 
 .contributors-wrapper {


### PR DESCRIPTION
<img width="840" alt="Screenshot 2025-01-31 at 1 34 47 PM" src="https://github.com/user-attachments/assets/78d2dd87-7464-4432-bf43-abf61ce87022" />

fix #28 
**Description of this commit:**
- Applied word-break to the left sidebar so that words break onto the next line when they overflow.
- Temporarily set the maximum width of the left sidebar to 15rem. Feel free to adjust it to a more suitable approach when working on mobile responsiveness later. (@sameera-g-mathad)

